### PR TITLE
Update markdownify.go

### DIFF
--- a/markdownify.go
+++ b/markdownify.go
@@ -10,7 +10,7 @@ import (
 	"strings"
 	"unicode"
 
-	"code.google.com/p/go.net/html"
+	"golang.org/x/net/html"
 	"github.com/PuerkitoBio/goquery"
 )
 


### PR DESCRIPTION
Apparently, the package goquery been changed. Now package goguery other ways to import the package html. This file also need to change in order to compile it with the new version package goquery
