### PR TITLE
Update net/html import path to new location.

### DIFF
--- a/markdownify.go
+++ b/markdownify.go
@@ -10,7 +10,7 @@ import (
 	"strings"
 	"unicode"
 
-	"code.google.com/p/go.net/html"
+	"golang.org/x/net/html"
 	"github.com/PuerkitoBio/goquery"
 )
 


### PR DESCRIPTION
Using the old location will cause the build to break, unless the old library already lives locally on the build machine.