### PR TITLE
Allow properties without a selector

### DIFF
--- a/scraper.go
+++ b/scraper.go
@@ -16,13 +16,13 @@ import (
 	"github.com/PuerkitoBio/goquery"
 )
 
-type DebugLogger interface {
+type debugLogger interface {
 	Printf(format string, v ...interface{})
 	Print(v ...interface{})
 }
 
 type debugger struct {
-	logger DebugLogger
+	logger debugLogger
 	debug  bool
 }
 
@@ -42,13 +42,13 @@ var debuglog = &debugger{
 	logger: log.New(os.Stderr, "SCRAPER DEBUG - ", log.LstdFlags),
 }
 
-// Set boolean flag to enable logging
+// Debug sets boolean flag to enable logging
 func Debug(debug bool) {
 	debuglog.debug = debug
 }
 
-// Sets the debug logger. By default it logs to STDERR
-func DefaultDebugLogger(logger DebugLogger) {
+// DefaultDebugLogger sets the debug logger. By default it logs to STDERR
+func DefaultDebugLogger(logger debugLogger) {
 	debuglog.logger = logger
 }
 

--- a/scraper.go
+++ b/scraper.go
@@ -175,7 +175,10 @@ func (s *Each) scrape(sel *goquery.Selection) (key string, value []map[string]in
 
 func (s *Property) scrape(sel *goquery.Selection) (key string, value interface{}, err error) {
 	key = s.Name
-	find := sel.Find(s.Selector)
+	find := sel
+	if s.Selector != "" {
+		find = sel.Find(s.Selector)
+	}
 	value = find
 	debuglog.Printf("Property %v from %v matches", s.Name, find.Length())
 


### PR DESCRIPTION
This allows definitions like this:

```xml
<Each name="links" selector="a">
  <Property name="text"/>
  <Property name="link">
    <Filter type="attr" argument="href"/>
  </Property>
</Each>
```