### PR TITLE
Fix google-api example: Wrong local hostname

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ func main() {
 	}
 
 	http.HandleFunc("/search", scraper.NewHTTPHandlerFunc(getUrl))
-	fmt.Println("Started API server. You can test it in http://0.0.0.0:12345/search?q=scraperboard")
+	fmt.Println("Started API server. You can test it in http://localhost:12345/search?q=scraperboard")
 	err = http.ListenAndServe(":12345", nil)
 	if err != nil {
 		fmt.Println("ListenAndServe: ", err)

--- a/examples/google-api/google-api.go
+++ b/examples/google-api/google-api.go
@@ -22,7 +22,7 @@ func main() {
 	}
 
 	http.HandleFunc("/search", scraper.NewHTTPHandlerFunc(getURL))
-	fmt.Println("Started API server. You can test it in http://0.0.0.0:12345/search?q=scraperboard")
+	fmt.Println("Started API server. You can test it in http://localhost:12345/search?q=scraperboard")
 	err = http.ListenAndServe(":12345", nil)
 	if err != nil {
 		fmt.Println("ListenAndServe: ", err)


### PR DESCRIPTION
Google-api example and README show wrong API server endpoint.
Should replace: fmt.Println("Started API server. You can test it in http://0.0.0.0:12345/search?q=scraperboard")
by: fmt.Println("Started API server. You can test it in http://localhost:12345/search?q=scraperboard")